### PR TITLE
Add missing header file

### DIFF
--- a/inc/sensor_dallas_ds18b20.h
+++ b/inc/sensor_dallas_ds18b20.h
@@ -12,6 +12,7 @@
 #ifndef __DS18B20_H__
 #define __DS18B20_H__
 
+#include <stdint.h>
 #include <rthw.h>
 #include <rtthread.h>
 #include <rtdevice.h>


### PR DESCRIPTION
在新版本的 RT-Thread 中，`stdint.h` 需要单独包含。